### PR TITLE
WIP: building under macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ VideoParser/VideoStatHEVC.os
 VideoParser/VideoStatVP9.o
 VideoParser/VideoStatVP9.os
 VideoParser/libvideoparser.so
+VideoParser/libvideoparser.dylib
 VideoParser/videoparser_testmain
 __pycache__/
 PythonInterface/lib/__pycache__/*

--- a/PythonInterface/lib/parserinterface.py
+++ b/PythonInterface/lib/parserinterface.py
@@ -14,7 +14,7 @@ class ParserInterface:
         self.dll_file = dll_file
 
         if not os.path.isfile(self.dll_file):
-            raise IOError("DLL file not found")
+            raise IOError("DLL file not found at " + self.dll_file)
 
         self.dll = CDLL(self.dll_file)
         self.decoded_frames = 0

--- a/PythonInterface/parse.py
+++ b/PythonInterface/parse.py
@@ -15,6 +15,14 @@ import json
 import bz2
 import gzip
 
+from sys import platform
+if platform == "linux" or platform == "linux2":
+    lib_suffix = ".so"
+elif platform == "darwin":
+    lib_suffix = ".dylib"
+elif platform == "win32":
+    lib_suffix = ".dll"
+
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
 import lib.videoparser as videoparser
@@ -44,8 +52,8 @@ def main():
     parser.add_argument(
         "--dll",
         type=str,
-        default="../VideoParser/libvideoparser.so",
-        help="Path to DLL",
+        default="../VideoParser/libvideoparser" + lib_suffix,
+        help="Path to DLL/.so/.dylib",
     )
     parser.add_argument(
         "--output",

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ pip3 install --user --upgrade pip
 pip3 install --user pandas
 ```
 
+Under macOS, you can get the dependencies with Homebrew:
+
+```bash
+brew install python3 scons
+pip3 install --user pandas
+```
+
 If you want to run the parser under Windows, please check out [the Development guide](./development.md).
 
 ## Building

--- a/ffmpeg/configure_ffmpeg.sh
+++ b/ffmpeg/configure_ffmpeg.sh
@@ -1,43 +1,84 @@
 #!/bin/sh
 
-./configure  \
-  --prefix="../Outputs" \
-  --cc=x86_64-linux-gnu-gcc \
-  --cxx=x86_64-linux-gnu-g++\
-  --ar=x86_64-linux-gnu-ar \
-  --extra-cflags="-Wno-error=implicit-function-declaration" \
-  --disable-programs \
-  --disable-doc \
-  --disable-stripping \
-  --enable-shared \
-  --enable-pthreads \
-  --enable-debug=2 \
-  --disable-avdevice \
-  --disable-avfilter \
-  --disable-swscale \
-  --disable-swresample \
-  --disable-nvenc \
-  --disable-vaapi \
-  --enable-decoder=aac \
-  --enable-parser=aac \
-  --enable-demuxer=aac \
-  --enable-decoder=mp3 \
-  --enable-demuxer=mp3 \
-  --enable-decoder=vorbis \
-  --enable-parser=vorbis \
-  --enable-decoder=opus \
-  --enable-parser=opus \
-  --enable-decoder=h264 \
-  --enable-decoder=mpeg4 \
-  --enable-parser=h264 \
-  --enable-demuxer=h264 \
-  --enable-demuxer=m4v \
-  --enable-demuxer=mpegts \
-  --enable-decoder=hevc \
-  --enable-parser=hevc \
-  --enable-demuxer=hevc \
-  --enable-decoder=vp9 \
-  --enable-parser=vp9 \
-  --enable-demuxer=matroska \
-  --enable-protocol=file
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  ./configure  \
+    --prefix="../Outputs" \
+    --extra-cflags="-Wno-error=implicit-function-declaration" \
+    --disable-programs \
+    --disable-doc \
+    --disable-stripping \
+    --enable-shared \
+    --enable-pthreads \
+    --enable-debug=2 \
+    --disable-avdevice \
+    --disable-avfilter \
+    --disable-swscale \
+    --disable-swresample \
+    --disable-nvenc \
+    --disable-vaapi \
+    --enable-decoder=aac \
+    --enable-parser=aac \
+    --enable-demuxer=aac \
+    --enable-decoder=mp3 \
+    --enable-demuxer=mp3 \
+    --enable-decoder=vorbis \
+    --enable-parser=vorbis \
+    --enable-decoder=opus \
+    --enable-parser=opus \
+    --enable-decoder=h264 \
+    --enable-decoder=mpeg4 \
+    --enable-parser=h264 \
+    --enable-demuxer=h264 \
+    --enable-demuxer=m4v \
+    --enable-demuxer=mpegts \
+    --enable-decoder=hevc \
+    --enable-parser=hevc \
+    --enable-demuxer=hevc \
+    --enable-decoder=vp9 \
+    --enable-parser=vp9 \
+    --enable-demuxer=matroska \
+    --enable-protocol=file
+else
+  ./configure  \
+    --prefix="../Outputs" \
+    --cc=x86_64-linux-gnu-gcc \
+    --cxx=x86_64-linux-gnu-g++\
+    --ar=x86_64-linux-gnu-ar \
+    --extra-cflags="-Wno-error=implicit-function-declaration" \
+    --disable-programs \
+    --disable-doc \
+    --disable-stripping \
+    --enable-shared \
+    --enable-pthreads \
+    --enable-debug=2 \
+    --disable-avdevice \
+    --disable-avfilter \
+    --disable-swscale \
+    --disable-swresample \
+    --disable-nvenc \
+    --disable-vaapi \
+    --enable-decoder=aac \
+    --enable-parser=aac \
+    --enable-demuxer=aac \
+    --enable-decoder=mp3 \
+    --enable-demuxer=mp3 \
+    --enable-decoder=vorbis \
+    --enable-parser=vorbis \
+    --enable-decoder=opus \
+    --enable-parser=opus \
+    --enable-decoder=h264 \
+    --enable-decoder=mpeg4 \
+    --enable-parser=h264 \
+    --enable-demuxer=h264 \
+    --enable-demuxer=m4v \
+    --enable-demuxer=mpegts \
+    --enable-decoder=hevc \
+    --enable-parser=hevc \
+    --enable-demuxer=hevc \
+    --enable-decoder=vp9 \
+    --enable-parser=vp9 \
+    --enable-demuxer=matroska \
+    --enable-protocol=file
+fi
+
 

--- a/parser.sh
+++ b/parser.sh
@@ -4,4 +4,5 @@ scriptPath=${0%/*}
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"$scriptPath/Outputs/lib"
 #gdb -ex=run --arg
 #gdb --args
-python3 "$scriptPath/PythonInterface/parse.py" "$@" --dll "$scriptPath/VideoParser/libvideoparser.so"
+python3 "$scriptPath/PythonInterface/parse.py" "$@"
+


### PR DESCRIPTION
Adaptations for building it under macOS.

Still does not work:

```
LD	libavcodec/libavcodec.57.dylib
Undefined symbols for architecture x86_64:
  "_BlackBorderEstimationHEVC", referenced from:
      _hls_decode_entry in hevc.o
  "_BlackborderDetect", referenced from:
      _decode_slice in h264_slice.o
  "_CoefStatisticsHEVC", referenced from:
      _ff_hevc_hls_residual_coding in hevc_cabac.o
  "_CurrBlackBorder", referenced from:
      _decode_slice in h264_slice.o
      _hls_decode_entry in hevc.o
  "_FrameStatistics", referenced from:
      _vp9_decode_frame in vp9.o
  "_InitFrameStatistics264", referenced from:
      _decode_slice in h264_slice.o
  "_InitFrameStatisticsVP9", referenced from:
      _vp9_decode_frame in vp9.o
  "_InitStatisticsHEVC", referenced from:
      _hls_decode_entry in hevc.o
  "_MbStatistcsHEVC", referenced from:
      _hls_coding_quadtree in hevc.o
  "_MbStatistics264", referenced from:
      _ff_h264_hl_decode_mb in h264_mb.o
  "_ModeStatistics", referenced from:
      _decode_b in vp9.o
  "_SaveDCs264", referenced from:
      _hl_decode_mb_complex in h264_mb.o
      _hl_decode_mb_simple_16 in h264_mb.o
      _hl_decode_mb_simple_8 in h264_mb.o
  "_TransfStatHEVC", referenced from:
      _hls_transform_tree in hevc.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [libavcodec/libavcodec.57.dylib] Error 1
```